### PR TITLE
Fix bug of Java wrapper APIs

### DIFF
--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/issuer/IssuerApi.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/issuer/IssuerApi.java
@@ -155,20 +155,20 @@ public class IssuerApi extends VcxJava.API {
     }
     private static Callback issuerSendCredentialCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
-        public void callback(int commandHandle, int err, String credentialDefId) {
-            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], credentialDefId = [" + credentialDefId + "]");
-            CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(commandHandle);
+        public void callback(int commandHandle, int err) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
             if (!checkCallback(future, err)) return;
-            future.complete(credentialDefId);
+            future.complete(err);
         }
     };
 
-    public static CompletableFuture<String> issuerSendCredential(int credentialHandle,
+    public static CompletableFuture<Integer> issuerSendCredential(int credentialHandle,
                                                                  int connectionHandle) throws VcxException {
         ParamGuard.notNull(credentialHandle, "credentialHandle");
         ParamGuard.notNull(connectionHandle, "connectionHandle");
         logger.debug("issuerSendCredential() called with: credentialHandle = [" + credentialHandle + "], connectionHandle = [" + connectionHandle + "]");
-        CompletableFuture<String> future = new CompletableFuture<>();
+        CompletableFuture<Integer> future = new CompletableFuture<>();
         int issue = addFuture(future);
 
         int result = LibVcx.api.vcx_issuer_send_credential(

--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
@@ -123,8 +123,8 @@ public class DisclosedProofApi extends VcxJava.API {
 
     private static Callback vcxProofGetStateCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
-        public void callback(int commandHandle, int err, int proofHandle, int state) {
-            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], proofHandle = [" + proofHandle + "], state = [" + state + "]");
+        public void callback(int commandHandle, int err, int state) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], state = [" + state + "]");
             CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
             if (!checkCallback(future, err)) return;
             future.complete(state);


### PR DESCRIPTION
issuerSendCredentialCB - Remove credentialDefId parameter (incurred error)
vcxProofGetStateCB - Remove proofHandle parameter (returned wrong state)

Signed-off-by: Ethan Sung <baegjae@gmail.com>