### PR TITLE
vcx android build script

### DIFF
--- a/libvcx/build_scripts/android/vcx/build.sh
+++ b/libvcx/build_scripts/android/vcx/build.sh
@@ -88,11 +88,11 @@ else
     echo "Skipping download android-ndk-r20-linux-x86_64.zip"
 fi
 
-_SDK_REPO="git@github.com:evernym/sdk.git"
+_SDK_REPO="https://github.com/AbsaOSS/libvcx.git"
 
 if [ ! -d "sdk" ] ; then
     echo "git cloning sdk"
-    git clone --branch ${GIT_INSTALL} ${_SDK_REPO}
+    git clone --branch ${GIT_INSTALL} ${_SDK_REPO} sdk
 else
     echo "Skipping git clone of sdk"
     _GIT_BRANCH=$(git --git-dir sdk/.git branch | head -n 1 | sed -e 's/^..//g')

--- a/libvcx/build_scripts/android/vcx/build_libraries.sh
+++ b/libvcx/build_scripts/android/vcx/build_libraries.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+workdir=output
+libdir=${workdir}/libs
+vcxdir=${workdir}/vcx
+
+libindy_version=1.15.0
+libvcx_version=0.8.2
+
+mkdir -p ${workdir}/libs
+mkdir -p ${vcxdir}/libvcx_x86
+mkdir -p ${vcxdir}/libvcx_arm64
+mkdir -p ${vcxdir}/libvcx_armv7
+
+chmod +x build.sh
+
+download_prebuilt_libs(){
+    pushd ${libdir}
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/openssl/openssl_x86.zip
+    unzip openssl_x86.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/openssl/openssl_arm64.zip
+    unzip openssl_arm64.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/openssl/openssl_armv7.zip
+    unzip openssl_armv7.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/sodium/libsodium_x86.zip
+    unzip libsodium_x86.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/sodium/libsodium_arm64.zip
+    unzip libsodium_arm64.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/sodium/libsodium_armv7.zip
+    unzip libsodium_armv7.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/zmq/libzmq_x86.zip
+    unzip libzmq_x86.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/zmq/libzmq_arm64.zip
+    unzip libzmq_arm64.zip
+
+    wget https://repo.sovrin.org/android/libindy/deps-libc%2B%2B/zmq/libzmq_armv7.zip
+    unzip libzmq_armv7.zip
+
+    wget "https://repo.sovrin.org/android/libindy/stable/${libindy_version}/libindy_android_x86_${libindy_version}.zip"
+    unzip libindy_android_x86_${libindy_version}.zip
+
+    wget "https://repo.sovrin.org/android/libindy/stable/${libindy_version}/libindy_android_arm64_${libindy_version}.zip"
+    unzip libindy_android_arm64_${libindy_version}.zip
+
+    wget "https://repo.sovrin.org/android/libindy/stable/${libindy_version}/libindy_android_armv7_${libindy_version}.zip"
+    unzip libindy_android_armv7_${libindy_version}.zip
+    popd
+}
+
+deploy_library(){
+    arch=$1
+    cp libvcx.so ${vcxdir}/libvcx_${arch}
+    pushd ${vcxdir}
+    zip -r libvcx_${arch}_${libvcx_version}.zip libvcx_${arch}
+    #Place your deployment script below
+    #curl -v --user 'id:pw' --upload-file ./libvcx_${arch}_${libvcx_version}.zip http://13.125.219.189/repository/libraries/android/libvcx_${arch}_${libvcx_version}.zip
+    popd
+}
+
+download_prebuilt_libs
+
+./build.sh x86 21 i686-linux-android skt-develop ./output/libs/openssl_x86 ./output/libs/libsodium_x86 ./output/libs/libzmq_x86 ./output/libs/libindy_x86/lib
+deploy_library x86
+
+./build.sh arm 21 arm-linux-androideabi skt-develop ./output/libs/openssl_armv7 ./output/libs/libsodium_armv7 ./output/libs/libzmq_armv7 ./output/libs/libindy_armv7/lib
+deploy_library armv7
+
+./build.sh arm64 21 aarch64-linux-android skt-develop ./output/libs/openssl_arm64 ./output/libs/libsodium_arm64 ./output/libs/libzmq_arm64 ./output/libs/libindy_arm64/lib
+deploy_library arm64

--- a/libvcx/build_scripts/android/vcx/make_vcx.sh
+++ b/libvcx/build_scripts/android/vcx/make_vcx.sh
@@ -8,7 +8,7 @@ python3 ${ANDROID_NDK_ROOT}/build/tools/make_standalone_toolchain.py --arch ${TA
 cat << EOF > .cargo/config
 [target.${CROSS_COMPILE}]
 ar = "${AR}"
-linker = "${CC}"
+linker = "${CXX}"
 EOF
 
 rustup target add ${CROSS_COMPILE}
@@ -16,5 +16,5 @@ rustup target add ${CROSS_COMPILE}
 cd "${HOME}/sdk/vcx/libvcx"
 export OPENSSL_STATIC=1
 cargo build --release --target=${CROSS_COMPILE}
-$CC -shared -o ${HOME}/libvcx.so -Wl,--whole-archive ${HOME}/sdk/vcx/libvcx/target/${CROSS_COMPILE}/release/libvcx.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/libz.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/libm.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/liblog.so ${LIBINDY_DIR}/libindy.a ${OPENSSL_DIR}/lib/libssl.a ${OPENSSL_DIR}/lib/libcrypto.a ${SODIUM_LIB_DIR}/libsodium.a ${LIBZMQ_LIB_DIR}/libzmq.a ${TOOLCHAIN_DIR}/${CROSS_COMPILE}/lib/libstdc++.a -Wl,--no-whole-archive -z muldefs
+$CXX -shared -o ${HOME}/libvcx.so -Wl,--whole-archive ${HOME}/sdk/vcx/libvcx/target/${CROSS_COMPILE}/release/libvcx.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/${CROSS_COMPILE}/libz.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/${CROSS_COMPILE}/libm.a ${TOOLCHAIN_DIR}/sysroot/usr/lib/${CROSS_COMPILE}/${TARGET_API}/liblog.so ${LIBINDY_DIR}/libindy.a ${OPENSSL_DIR}/lib/libssl.a ${OPENSSL_DIR}/lib/libcrypto.a ${SODIUM_LIB_DIR}/libsodium.a ${LIBZMQ_LIB_DIR}/libzmq.a -Wl,--no-whole-archive -z muldefs
 cp "${HOME}/sdk/vcx/libvcx/target/${CROSS_COMPILE}/release/libvcx.a" ${HOME}/


### PR DESCRIPTION
This is an android build script using docker. If you run `build_libraries.sh` it will create folders `libs` and `vcx`
`libs`: download prebuilt libries for three different architectures (x86, arm64, armv7) such as `libindy`, `libsodium`, `libzmq`, `openssl`
`vcx`: have `libvcx.so` file for each architecture, and zip them to be ready for uploading