### PR TITLE
Generate unique wallet name in export tests

### DIFF
--- a/libvcx/src/utils/libindy/wallet.rs
+++ b/libvcx/src/utils/libindy/wallet.rs
@@ -251,7 +251,7 @@ pub mod tests {
     }
 
     pub fn export_test_wallet() -> (TempFile, String) {
-        let wallet_name = "export_test_wallet";
+        let wallet_name = &format!("export_test_wallet_{}", uuid::Uuid::new_v4());
 
         let export_file = TempFile::prepare_path(wallet_name);
 


### PR DESCRIPTION
Because all tests were using same wallet name, if one test failed, it would other tests assumptions (about the wallet not yet existing), causing the to fail. 