### PR TITLE
Prevent panics when cleaning up tests

### DIFF
--- a/libvcx/src/utils/devsetup.rs
+++ b/libvcx/src/utils/devsetup.rs
@@ -370,7 +370,8 @@ pub fn setup_indy_env(use_zero_fees: bool) {
 }
 
 pub fn cleanup_indy_env() {
-    delete_wallet(settings::DEFAULT_WALLET_NAME, None, None, None).unwrap();
+    delete_wallet(settings::DEFAULT_WALLET_NAME, None, None, None)
+        .unwrap_or_else(|_| error!("Error deleting wallet {}", settings::DEFAULT_WALLET_NAME));
     delete_test_pool();
 }
 


### PR DESCRIPTION
Test are using various structures like SetupWallet, SetupWalletAndPool, SetupLibraryWallet, each implements function called `init()` different - some implementations prepare pool and wallet, some only wallet. Tests are using these structures based on what they need. These structures also implement `Drop()`, where they cleanup the resources created in `init()`.

If test panics, `Drop` on this structure is also called. However, the Drop implementation was closing wallet and panicking on failure to do so. So if a test panicked and for some reason, closing wallet in `Drop` panicked as well, the original panic from the test itself was getting lost. So with this change, if cleanup in Drop fails, it doesn't panic, just logs the error. The original test panic then gets properly propagated and is logged.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>