### PR TITLE
Enable codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,87 +203,87 @@ jobs:
       - name: Verify libvcx image was loaded
         run: |
           docker image ls --format "{{.Repository}}:{{.Tag}}" | grep "$DOCKER_IMG_NAME_LIBVCX" || { echo "Image $DOCKER_IMG_NAME_LIBVCX was not found!" ; exit 1; }
-#
-#  build-image-codecov:
-#    needs: workflow-setup
-#    runs-on: ubuntu-latest
-#    env:
-#      DOCKER_BUILDKIT: 1
-#    steps:
-#      - name: Load up custom variables
-#        run: |
-#          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
-#          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
-#      - name: Git checkout
-#        uses: actions/checkout@v2
-#      - name: Try load from cache.
-#        id: cache-image-codecov
-#        uses: actions/cache@v2
-#        with:
-#          path: /tmp/imgcache
-#          key: ${{ env.CACHE_KEY_CODECOV }}
-#      - name: If NOT found in cache, build and cache image.
-#        if: steps.cache-image-codecov.outputs.cache-hit != 'true'
-#        run: |
-#          set -x
-#          docker build -f ci/libvcx-ubuntu.dockerfile \
-#                       -t "$DOCKER_IMG_NAME_CODECOV" \
-#                        .
-#          mkdir -p /tmp/imgcache
-#          docker save "$DOCKER_IMG_NAME_CODECOV" > /tmp/imgcache/img_codecov.rar
-#
-#      - name: Load codecov image from cache
-#        run: |
-#          docker load < /tmp/imgcache/img_codecov.rar
-#      - name: Verify codecov image was loaded
-#        run: |
-#          docker image ls --format "{{.Repository}}:{{.Tag}}" | grep "$DOCKER_IMG_NAME_CODECOV" || { echo "Image $DOCKER_IMG_NAME_CODECOV was not found!" ; exit 1; }
-#
-#  code-coverage-unit-tests:
-#    runs-on: ubuntu-latest
-#    needs: [workflow-setup, build-image-codecov]
-#    env:
-#      DOCKER_BUILDKIT: 1
-#    steps:
-#      - name: Git checkout
-#        uses: actions/checkout@v2
-#      - name: Docker setup
-#        run: |
-#          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
-#          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
-#
-#      - name: Load codecov image cache
-#        id: load-cached-codecov-image
-#        uses: actions/cache@v2
-#        with:
-#          path: /tmp/imgcache
-#          key: ${{ env.CACHE_KEY_CODECOV }}
-#      - name: If no cached image found
-#        if: steps.load-cached-codecov-image.outputs.cache-hit != 'true'
-#        run: echo "ERROR == Expected to find image from cache $CACHE_KEY_CODECOV"; exit -1
-#      - name: Load image from cache
-#        run: docker load < /tmp/imgcache/img_codecov.rar
-#
-#      - run: mkdir -p /tmp/artifacts/coverage
-#
-#      - name: Run quick unit tests
-#        uses: ./.github/actions/codecov-unit-tests
-#        with:
-#          docker-img-name: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV }}
-#          cov-file-path: libvcx/coverage.lcov
-#
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v1
-#        with:
-#          file: libvcx/coverage.lcov
-#          flags: unittests
-#          name: codecov-unit-tests
-#          fail_ci_if_error: true
-#          path_to_write_report: /tmp/artifacts/coverage/codecov_report.gz
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: code-coverage-report-unit-tests
-#          path: /tmp/artifacts/coverage
+
+  build-image-codecov:
+    needs: workflow-setup
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Load up custom variables
+        run: |
+          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
+          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Try load from cache.
+        id: cache-image-codecov
+        uses: actions/cache@v2
+        with:
+          path: /tmp/imgcache
+          key: ${{ env.CACHE_KEY_CODECOV }}
+      - name: If NOT found in cache, build and cache image.
+        if: steps.cache-image-codecov.outputs.cache-hit != 'true'
+        run: |
+          set -x
+          docker build -f ci/libvcx-ubuntu.dockerfile \
+                       -t "$DOCKER_IMG_NAME_CODECOV" \
+                        .
+          mkdir -p /tmp/imgcache
+          docker save "$DOCKER_IMG_NAME_CODECOV" > /tmp/imgcache/img_codecov.rar
+
+      - name: Load codecov image from cache
+        run: |
+          docker load < /tmp/imgcache/img_codecov.rar
+      - name: Verify codecov image was loaded
+        run: |
+          docker image ls --format "{{.Repository}}:{{.Tag}}" | grep "$DOCKER_IMG_NAME_CODECOV" || { echo "Image $DOCKER_IMG_NAME_CODECOV was not found!" ; exit 1; }
+
+  code-coverage-unit-tests:
+    runs-on: ubuntu-latest
+    needs: [workflow-setup, build-image-codecov]
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Docker setup
+        run: |
+          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
+          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
+
+      - name: Load codecov image cache
+        id: load-cached-codecov-image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/imgcache
+          key: ${{ env.CACHE_KEY_CODECOV }}
+      - name: If no cached image found
+        if: steps.load-cached-codecov-image.outputs.cache-hit != 'true'
+        run: echo "ERROR == Expected to find image from cache $CACHE_KEY_CODECOV"; exit -1
+      - name: Load image from cache
+        run: docker load < /tmp/imgcache/img_codecov.rar
+
+      - run: mkdir -p /tmp/artifacts/coverage
+
+      - name: Run quick unit tests
+        uses: ./.github/actions/codecov-unit-tests
+        with:
+          docker-img-name: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV }}
+          cov-file-path: libvcx/coverage.lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: libvcx/coverage.lcov
+          flags: unittests
+          name: codecov-unit-tests
+          fail_ci_if_error: true
+          path_to_write_report: /tmp/artifacts/coverage/codecov_report.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report-unit-tests
+          path: /tmp/artifacts/coverage
 
 #   code-coverage-integration-tests:
 #     runs-on: ubuntu-latest

--- a/ci/libvcx-ubuntu.dockerfile
+++ b/ci/libvcx-ubuntu.dockerfile
@@ -5,7 +5,7 @@ ARG UID=1000
 ARG INDYSDK_PATH=/home/indy/indy-sdk
 ARG INDYSDK_REVISION=v1.15.0
 ARG INDYSDK_REPO=https://github.com/hyperledger/indy-sdk
-ARG RUST_VER=nightly
+ARG RUST_VER=nightly-2020-08-20
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
The codecov test panics were due to [this change](https://github.com/rust-lang/rust/pull/66059), mentioned on [this](https://github.com/sebcrozet/kiss3d/issues/249) and [this](https://github.com/rust-lang/rust/issues/73573) issue. The error backtrace is:
```
test api::vcx::tests::test_import_after_init_fails ... thread '<unnamed>' panicked at 'attempted to leave type `linked_hash_map::Node<std::string::String, raw_statement::RawStatement>` uninitialized, which is invalid', /rustc/25c8c53dd994acb3f4f7c02fe6bb46076393f8b0/library/core/src/mem/mod.rs:658:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/25c8c53dd994acb3f4f7c02fe6bb46076393f8b0/library/std/src/panicking.rs:483
   1: core::panicking::panic_fmt
             at /rustc/25c8c53dd994acb3f4f7c02fe6bb46076393f8b0/library/core/src/panicking.rs:85
   2: core::panicking::panic
             at /rustc/25c8c53dd994acb3f4f7c02fe6bb46076393f8b0/library/core/src/panicking.rs:50
   3: linked_hash_map::LinkedHashMap<K,V,S>::insert
   4: <rusqlite::cache::CachedStatement as core::ops::drop::Drop>::drop
   5: <indy_wallet::storage::default::SQLiteStorage as indy_wallet::storage::WalletStorage>::add
   6: indy_wallet::wallet::Wallet::add
   7: indy_wallet::WalletService::add_record
   8: indy_wallet::WalletService::add_indy_object
   9: indy::commands::did::DidCommandExecutor::execute
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

To read: https://doc.rust-lang.org/nomicon/unchecked-uninit.html